### PR TITLE
Clarify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,11 @@ Once complete, you can now view your new site at https://my-project.dev.
 This command leverages [Laravel Valet](https://laravel.com/docs/5.2/valet#installation) which is installed globally via Composer.
 Follow the [installation instructions](https://laravel.com/docs/5.2/valet#installation) on the Laravel documentation to get started.
 
+Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
+Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`
+
 ## Database Options
 New sites create a new MySQL database by default, but the `new` command also supports using [SQLite](https://www.sqlite.org/) for a completely portable install. Simply add `--db=sqlite` when running `wp valet new`.
-
-Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
-
-Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`
 
 ## Contributing
 


### PR DESCRIPTION
Previously the command to install was hidden in the database options section which could easily be overlooked.

This moves it to the Installing section, where it belongs.