### PR TITLE
Pass dbpass argument to core config

### DIFF
--- a/src/Valet_Command.php
+++ b/src/Valet_Command.php
@@ -188,6 +188,7 @@ class Valet_Command
         $this->wp('core config', [], [
             'dbname'   => $this->args['dbname'] ?: "wp_{$this->site_name}",
             'dbuser'   => $this->args['dbuser'],
+            'dbpass'   => $this->args['dbpass'],
             'dbprefix' => $this->args['dbprefix'],
         ]);
     }


### PR DESCRIPTION
Currently when running `valet new`, the dbpass argument is not passed to core config. If a password is set for the mysql user, the process will error out with `Error: ERROR 1045 (28000): Access denied for user 'xxxx'@'localhost' (using password: NO)`

This patch just adds the dbpass parameter to the call to core config.