### PR TITLE
Configurable install path

### DIFF
--- a/features/valet-new-project-bedrock.feature
+++ b/features/valet-new-project-bedrock.feature
@@ -32,3 +32,12 @@ Feature: It can create new installs for Valet-supported WordPress projects.
 
     When I run `wp valet destroy {PROJECT} --yes`
     Then the {PROJECT} directory should not exist
+
+  @issue-10
+  Scenario: It can create a new Bedrock install using the given path to the parent dir.
+    Given an empty directory
+    And a random project name as {PROJECT}
+    And a random string as {PATH}
+
+    When I run `wp valet new {PROJECT} --project=bedrock --in={PATH} --debug`
+    Then the {PATH}/{PROJECT}/.env file should exist

--- a/features/valet-new.feature
+++ b/features/valet-new.feature
@@ -20,27 +20,30 @@ Feature: Create a new install.
       Success: {PROJECT} ready! http://{PROJECT}.dev
       """
 
+  @issue-10
   Scenario: It accepts options for configuring the new install.
     Given an empty directory
     And a random project name as {PROJECT}
     And a random string as {ADMIN}
+    And a random string as {PATH}
 
-    When I run `wp valet new {PROJECT} --admin_user={ADMIN} --admin_email=hello@{PROJECT}.dev --version=4.5 --dbname=wp_cli_test --dbprefix={ADMIN}_ --dbuser=wp_cli_test --dbpass=password1`
+    When I run `wp valet new {PROJECT} --in={PATH} --admin_user={ADMIN} --admin_email=hello@{PROJECT}.dev --version=4.5 --dbname=wp_cli_test --dbprefix={ADMIN}_ --dbuser=wp_cli_test --dbpass=password1`
+    Then the {PATH}/{PROJECT}/wp-config.php file should exist
     Then the wp_cli_test database should exist
 
-    When I run `wp db tables --path={PROJECT}`
+    When I run `wp db tables --path={PATH}/{PROJECT}`
     Then STDOUT should contain:
       """
       {ADMIN}_users
       """
 
-    When I run `wp core version --path={PROJECT}`
+    When I run `wp core version --path={PATH}/{PROJECT}`
     Then STDOUT should be:
       """
       4.5
       """
 
-    When I run `wp user list --fields=ID,user_login,user_email --path={PROJECT}`
+    When I run `wp user list --fields=ID,user_login,user_email --path={PATH}/{PROJECT}`
     Then STDOUT should be a table containing rows:
       | ID | user_login   | user_email          |
       | 1  | {ADMIN}      | hello@{PROJECT}.dev |

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -18,6 +18,10 @@ class BedrockInstaller extends WordPressInstaller
     {
         Command::debug('Installing Bedrock via Composer');
 
+        if (! is_dir($full_path = $this->props->projectRoot())) {
+            mkdir($full_path, 0755, true);
+        }
+
         Composer::createProject('roots/bedrock', $this->props->site_name, [
             'working-dir'    => $this->props->parentDirectory(),
             'no-interaction' => true,

--- a/src/Installer/WordPressInstaller.php
+++ b/src/Installer/WordPressInstaller.php
@@ -47,7 +47,7 @@ class WordPressInstaller implements InstallerInterface
             'locale'  => $this->props->option('locale'),
         ]);
 
-        if (! is_dir($full_path = $this->props->fullPath())) {
+        if (! is_dir($full_path = $this->props->projectRoot())) {
             mkdir($full_path, 0755, true);
         }
 

--- a/src/Props.php
+++ b/src/Props.php
@@ -96,7 +96,7 @@ class Props
     public function fullPath($relative = '')
     {
         $parts = array_filter([
-            $this->option('path', getcwd()),
+            $this->option('in', getcwd()),
             $this->site_name,
             $relative
         ]);

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -74,6 +74,10 @@ class ValetCommand
      *   - bedrock
      * ---
      *
+     * [--in=<dir>]
+     * : Specify the path to the parent directory to create the install in.
+     * Defaults to the current working directory.
+     *
      * [--version=<version>]
      * : WordPress version to install.
      * ---


### PR DESCRIPTION
Per #10, it may be desirable to be able to pass the path to the install directory when creating a new install.  This was always the intention by referencing the global `--path` flag internally.

However, what wasn't obvious is that WP-CLI strips all global options out of the `$assoc_args` passed to a subcommand.  Even by defining it in the synopsis like [`core download`](https://github.com/wp-cli/wp-cli/blob/42cf7fb8846f58cc0ea4677ebce29ac91601cc79/php/commands/core.php#L91-L92) it will still be stripped unless [`WP_CLI_STRICT_ARGS_MODE`](wp-cli/wp-cli#3128) is enabled.

Rather than messing with this, it makes much more sense to just use a different option as the behavior is a bit different anyways.

This PR adds a `--in=<dir>` flag you can pass to `valet new` with a path to the desired install directory (ie: parent directory of the install). Because Valet uses the name of the install directory for the local domain name it is accessed with, the project directory will be installed _inside_ the given path.

i.e. If you were to run `wp valet new my-project --in=some/dir` the install directory would then be: `./some/dir/my-project` which would be accessed at `https://my-project.dev`
