### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "aaemnnosttv/wp-cli-valet-command",
     "description": "White-glove services for turn-key installs in seconds.",
+    "type": "wp-cli-package",
     "keywords": ["wordpress", "laravel", "valet", "zonda"],
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567