### PR TITLE
Updating docs to include newer, easier-to-use instructions 

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,9 +1,20 @@
 ### Prerequisites
 
-This command leverages [Laravel Valet](https://laravel.com/docs/5.2/valet#installation) -- the development environment for Mac minimalists.
-Because of this **support is unfortunately limited to Mac only**.
+This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
 
-Follow the [installation instructions](https://laravel.com/docs/5.2/valet#installation) on the Laravel documentation to get started.
-This is what makes it possible to load a site in your browser immediately after creating it, without any other configuration.
+You should also understand how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
 
-You will also need some understanding of how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
+#### DevEnv Set-Up
+1) MacOS users should set up [Homebrew](https://brew.sh/) first. 
+
+2) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
+
+> _Note: Linux users are encouraged to use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares the same `valet` commands powering this `wp-cli` plugin._
+
+3) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. Update, if needed, to the latest stable release with `wp cli update`.
+
+4) Your credentials to create a database should also be stored in `~/my.cnf`.
+
+#### Loading the wp-cli-valet-command package
+
+Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,5 +1,3 @@
-### Prerequisites
-
 This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. 
 
 It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
@@ -13,9 +11,7 @@ You should also understand how Valet works, especially the portion on [Serving S
 
 > _Note: Linux users should use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares most of the same `valet` commands powering this `wp-cli` plugin._
 
-2) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. 
-
-Confirm your `wp-cli` environment works by running `wp cli info` and proceed if the output looks something like:
+2) Confirm your `wp-cli` environment works and meets the minimum version specified below by running `wp cli info` and proceed if the output looks something like:
 ```
 PHP binary:	/usr/bin/php7.0
 PHP version:	7.0.22-0ubuntu0.16.04.1
@@ -31,39 +27,4 @@ WP-CLI version:	1.4.1
 
 Update, if needed, to the latest stable release with `wp cli update`.
 
-#### Setting defaults for the wp valet command
-As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
-
-Simply add the appropriate details in `~/.wp-cli/config.yml`:
-
-```
-valet new:
-	project: wp
-	# in: override - defaults to current directory
-    version: latest
-    # locale: - use if not English
-    db: mysql
-    # dbname: defaults to wp_name
-    dbuser: root # or any other local user capable of creating databases (MySQL only)
-    dbpass: # enter the appropriate password if necessary (MySQL only)
-    dbprefix: wp_
-    admin_user: admin
-    admin_pass: admin
-    # unsecure - use without colon if you'd like to override HTTPS
-    # portable - see above
-```
-
-The `wp valet new` defaults are shown here as an example for clarity.
-
 #### Loading the wp-cli-valet-command package
-
-Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
-
-#### Troubleshooting
-
-`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
-The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
-
-Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
-
-At this point, you can: 1) Either create a `wp-config.php` file manually or use the `wp config` command, or 2) use `wp valet destroy site` and try again using the `--dbpass` attribute.

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -1,20 +1,45 @@
 ### Prerequisites
 
-This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
+This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. 
+
+It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
 
 You should also understand how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
 
-#### DevEnv Set-Up
-1) MacOS users should set up [Homebrew](https://brew.sh/) first. 
+#### Environment Setup
+0) MacOS users should install [Homebrew](https://brew.sh/) first.
 
-2) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
+1) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
 
-> _Note: Linux users are encouraged to use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares the same `valet` commands powering this `wp-cli` plugin._
+> _Note: Linux users should use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares most of the same `valet` commands powering this `wp-cli` plugin._
 
-3) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. Update, if needed, to the latest stable release with `wp cli update`.
+2) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. 
 
-4) Your credentials to create a database should also be stored in `~/my.cnf`.
+Confirm your `wp-cli` environment works by running `wp cli info` and proceed if the output looks something like:
+```
+PHP binary:	/usr/bin/php7.0
+PHP version:	7.0.22-0ubuntu0.16.04.1
+php.ini used:	/etc/php/7.0/cli/php.ini
+WP-CLI root dir:	phar://wp-cli.phar
+WP-CLI vendor dir:	phar://wp-cli.phar/vendor
+WP_CLI phar path:	/home/user/wp-cli-valet-command
+WP-CLI packages dir:	/home/user/.wp-cli/packages/
+WP-CLI global config:	/home/user/.wp-cli/config.yml
+WP-CLI project config:	
+WP-CLI version:	1.4.1
+```
+
+Update, if needed, to the latest stable release with `wp cli update`.
 
 #### Loading the wp-cli-valet-command package
 
-Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
+Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
+
+### Troubleshooting
+
+`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
+The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
+
+Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
+
+At this point, you can: 1) Either create a `wp-config.php` file manually or use the `wp config` command, or 2) use `wp valet destroy site` and try again using the `--dbpass` attribute.

--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -31,11 +31,35 @@ WP-CLI version:	1.4.1
 
 Update, if needed, to the latest stable release with `wp cli update`.
 
+#### Setting defaults for the wp valet command
+As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
+
+Simply add the appropriate details in `~/.wp-cli/config.yml`:
+
+```
+valet new:
+	project: wp
+	# in: override - defaults to current directory
+    version: latest
+    # locale: - use if not English
+    db: mysql
+    # dbname: defaults to wp_name
+    dbuser: root # or any other local user capable of creating databases (MySQL only)
+    dbpass: # enter the appropriate password if necessary (MySQL only)
+    dbprefix: wp_
+    admin_user: admin
+    admin_pass: admin
+    # unsecure - use without colon if you'd like to override HTTPS
+    # portable - see above
+```
+
+The `wp valet new` defaults are shown here as an example for clarity.
+
 #### Loading the wp-cli-valet-command package
 
 Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
 
-### Troubleshooting
+#### Troubleshooting
 
 `Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
 The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# WP-CLI Valet Command
+aaemnnosttv/wp-cli-valet-command
+================================
 
 White-glove services for turn-key installs in seconds.
 
-[![Travis Build](https://img.shields.io/travis/aaemnnosttv/wp-cli-valet-command/master.svg)](https://travis-ci.org/aaemnnosttv/wp-cli-valet-command)
-[![Packagist](https://img.shields.io/packagist/v/aaemnnosttv/wp-cli-valet-command.svg)](https://packagist.org/packages/aaemnnosttv/wp-cli-valet-command)
+[![Travis Build](https://img.shields.io/travis/aaemnnosttv/wp-cli-valet-command/master.svg)](https://travis-ci.org/aaemnnosttv/wp-cli-valet-command) [![Packagist](https://img.shields.io/packagist/v/aaemnnosttv/wp-cli-valet-command.svg)](https://packagist.org/packages/aaemnnosttv/wp-cli-valet-command)
 
-Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contributing)
+Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contributing) | [Support](#support)
 
 ## Using
 
@@ -128,17 +128,30 @@ this install over https.
 
 ### Prerequisites
 
-This command leverages [Laravel Valet](https://laravel.com/docs/5.2/valet#installation) -- the development environment for Mac minimalists.
-Because of this **support is unfortunately limited to Mac only**.
+This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
 
-Follow the [installation instructions](https://laravel.com/docs/5.2/valet#installation) on the Laravel documentation to get started.
-This is what makes it possible to load a site in your browser immediately after creating it, without any other configuration.
+You should also have some understanding of how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
 
-You will also need some understanding of how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
+#### DevEnv Set-Up
+1) MacOS users should set up [Homebrew](https://brew.sh/) first. 
 
-Installing this package requires WP-CLI v0.23.0 or greater. Update to the latest stable release with `wp cli update`.
+2) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
+
+> _Note: Linux users are encouraged to use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares the same `valet` commands powering this `wp-cli` plugin._
+
+3) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. Update, if needed, to the latest stable release with `wp cli update`.
+
+4) Your credentials to create a database should also be stored in `~/my.cnf`.
+
+#### Loading the wp-cli-valet-command package
 
 Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
+
+Installing this package requires WP-CLI v1.3.0 or greater. Update to the latest stable release with `wp cli update`.
+
+Once you've done so, you can install this package with:
+
+    wp package install git@github.com:aaemnnosttv/wp-cli-valet-command.git
 
 ## Contributing
 
@@ -146,30 +159,25 @@ We appreciate you taking the initiative to contribute to this project.
 
 Contributing isn’t limited to just code. We encourage you to contribute in the way that best fits your abilities, by writing tutorials, giving a demo at your local meetup, helping other users with their support questions, or revising our documentation.
 
+For a more thorough introduction, [check out WP-CLI's guide to contributing](https://make.wordpress.org/cli/handbook/contributing/). This package follows those policy and guidelines.
+
 ### Reporting a bug
 
 Think you’ve found a bug? We’d love for you to help us get it fixed.
 
 Before you create a new issue, you should [search existing issues](https://github.com/aaemnnosttv/wp-cli-valet-command/issues?q=label%3Abug%20) to see if there’s an existing resolution to it, or if it’s already been fixed in a newer version.
 
-Once you’ve done a bit of searching and discovered there isn’t an open or fixed issue for your bug, please [create a new issue](https://github.com/aaemnnosttv/wp-cli-valet-command/issues/new) with the following:
-
-1. What you were doing (e.g. "When I run `wp post list`").
-2. What you saw (e.g. "I see a fatal about a class being undefined.").
-3. What you expected to see (e.g. "I expected to see the list of posts.")
-
-Include as much detail as you can, and clear steps to reproduce if possible.
+Once you’ve done a bit of searching and discovered there isn’t an open or fixed issue for your bug, please [create a new issue](https://github.com/aaemnnosttv/wp-cli-valet-command/issues/new). Include as much detail as you can, and clear steps to reproduce if possible. For more guidance, [review our bug report documentation](https://make.wordpress.org/cli/handbook/bug-reports/).
 
 ### Creating a pull request
 
 Want to contribute a new feature? Please first [open a new issue](https://github.com/aaemnnosttv/wp-cli-valet-command/issues/new) to discuss whether the feature is a good fit for the project.
 
-Once you've decided to commit the time to seeing your pull request through, please follow our guidelines for creating a pull request to make sure it's a pleasant experience:
+Once you've decided to commit the time to seeing your pull request through, [please follow our guidelines for creating a pull request](https://make.wordpress.org/cli/handbook/pull-requests/) to make sure it's a pleasant experience. See "[Setting up](https://make.wordpress.org/cli/handbook/pull-requests/#setting-up)" for details specific to working on this package locally.
 
-1. Create a feature branch for each contribution.
-2. Submit your pull request early for feedback.
-3. Include functional tests with your changes. [Read the WP-CLI documentation](https://wp-cli.org/docs/pull-requests/#functional-tests) for an introduction.
-4. Follow the [WordPress Coding Standards](http://make.wordpress.org/core/handbook/coding-standards/).
+## Support
+
+Github issues aren't for general support questions, but there are other venues you can try: http://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ White-glove services for turn-key installs in seconds.
 
 [![Travis Build](https://img.shields.io/travis/aaemnnosttv/wp-cli-valet-command/master.svg)](https://travis-ci.org/aaemnnosttv/wp-cli-valet-command) [![Packagist](https://img.shields.io/packagist/v/aaemnnosttv/wp-cli-valet-command.svg)](https://packagist.org/packages/aaemnnosttv/wp-cli-valet-command)
 
-Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contributing) | [Support](#support)
+Quick links: [Using](#using) | [Installing](#installing) | [Troubleshooting](#troubleshooting) | [Support](#support) | [Contributing](#contributing)
 
 ## Using
 
@@ -126,8 +126,6 @@ this install over https.
 
 ## Installing
 
-### Prerequisites
-
 This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. 
 
 It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
@@ -141,9 +139,7 @@ You should also understand how Valet works, especially the portion on [Serving S
 
 > _Note: Linux users should use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares most of the same `valet` commands powering this `wp-cli` plugin._
 
-2) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. 
-
-Confirm your `wp-cli` environment works by running `wp cli info` and proceed if the output looks something like:
+2) Confirm your `wp-cli` environment works and meets the minimum version specified below by running `wp cli info` and proceed if the output looks something like:
 ```
 PHP binary:	/usr/bin/php7.0
 PHP version:	7.0.22-0ubuntu0.16.04.1
@@ -159,48 +155,63 @@ WP-CLI version:	1.4.1
 
 Update, if needed, to the latest stable release with `wp cli update`.
 
-#### Setting defaults for the wp valet command
-As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
-
-Simply add the appropriate details in `~/.wp-cli/config.yml`:
-
-```
-valet new:
-	project: wp
-	# in: override - defaults to current directory
-    version: latest
-    # locale: - use if not English
-    db: mysql
-    # dbname: defaults to wp_name
-    dbuser: root # or any other local user capable of creating databases (MySQL only)
-    dbpass: # enter the appropriate password if necessary (MySQL only)
-    dbprefix: wp_
-    admin_user: admin
-    admin_pass: admin
-    # unsecure - use without colon if you'd like to override HTTPS
-    # portable - see above
-```
-
-The `wp valet new` defaults are shown here as an example for clarity.
-
 #### Loading the wp-cli-valet-command package
-
-Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
-
-#### Troubleshooting
-
-`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
-The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
-
-Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
-
-At this point, you can: 1) Either create a `wp-config.php` file manually or use the `wp config` command, or 2) use `wp valet destroy site` and try again using the `--dbpass` attribute.
 
 Installing this package requires WP-CLI v1.3.0 or greater. Update to the latest stable release with `wp cli update`.
 
 Once you've done so, you can install this package with:
 
     wp package install git@github.com:aaemnnosttv/wp-cli-valet-command.git
+
+## Troubleshooting
+
+`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
+The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
+
+Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
+
+At this point, you can: 
+1) Either create a `wp-config.php` file manually,
+2) use `wp config`command to have wp-cli create one for you, or 
+3) use `wp valet destroy site` and try running your `wp valet new` command again, this time using the `--dbpass` attribute.
+
+### Configuring Alternate Defaults
+As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
+
+Simply add the appropriate details in `~/.wp-cli/config.yml`:
+
+```yml
+valet new:
+  ## Uncomment or update the relevant lines when necessary to set your own defaults.
+  project: wp # or bedrock
+  # in: # override - defaults to current directory
+  version: latest
+  # locale:  # use if not English
+  db: mysql # or sqlite
+  # dbname: # defaults to wp_name
+  dbuser: root # or any other local user capable of creating databases (MySQL only)
+  # dbpass: # enter the appropriate password if necessary (MySQL only)
+  dbprefix: wp_
+  admin_user: admin
+  admin_pass: admin
+  ## Boolean options can also be configured, too.
+  # unsecure: false # set to true to override
+  # portable: false # set to true to override
+```
+
+The `wp valet new` defaults are shown here as an example for clarity.
+
+One simple usage for the `config.yml` could look like
+```yml
+valet new:
+  dbuser: root # or any db creating user
+  dbpass: password # set yours here
+```
+to enable `wp valet new site` to spin up a full, live, running local WordPress site in ~3 seconds without any additional parameters.
+
+## Support
+
+Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 ## Contributing
 
@@ -223,10 +234,6 @@ Once you’ve done a bit of searching and discovered there isn’t an open or fi
 Want to contribute a new feature? Please first [open a new issue](https://github.com/aaemnnosttv/wp-cli-valet-command/issues/new) to discuss whether the feature is a good fit for the project.
 
 Once you've decided to commit the time to seeing your pull request through, [please follow our guidelines for creating a pull request](https://make.wordpress.org/cli/handbook/pull-requests/) to make sure it's a pleasant experience. See "[Setting up](https://make.wordpress.org/cli/handbook/pull-requests/#setting-up)" for details specific to working on this package locally.
-
-## Support
-
-Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/README.md
+++ b/README.md
@@ -128,24 +128,49 @@ this install over https.
 
 ### Prerequisites
 
-This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
+This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. 
 
-You should also have some understanding of how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
+It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
 
-#### DevEnv Set-Up
-1) MacOS users should set up [Homebrew](https://brew.sh/) first. 
+You should also understand how Valet works, especially the portion on [Serving Sites](https://laravel.com/docs/5.2/valet#serving-sites).
 
-2) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
+#### Environment Setup
+0) MacOS users should install [Homebrew](https://brew.sh/) first.
 
-> _Note: Linux users are encouraged to use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares the same `valet` commands powering this `wp-cli` plugin._
+1) Follow the [Valet installation instructions](https://laravel.com/docs/valet#installation) on the Laravel documentation to get started.
 
-3) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. Update, if needed, to the latest stable release with `wp cli update`.
+> _Note: Linux users should use [Valet-linux](https://github.com/cpriego/valet-linux) instead, a fork of the original project that shares most of the same `valet` commands powering this `wp-cli` plugin._
 
-4) Your credentials to create a database should also be stored in `~/my.cnf`.
+2) Using this package also requires [WP-CLI](http://wp-cli.org/), v0.23.0 or greater. 
+
+Confirm your `wp-cli` environment works by running `wp cli info` and proceed if the output looks something like:
+```
+PHP binary:	/usr/bin/php7.0
+PHP version:	7.0.22-0ubuntu0.16.04.1
+php.ini used:	/etc/php/7.0/cli/php.ini
+WP-CLI root dir:	phar://wp-cli.phar
+WP-CLI vendor dir:	phar://wp-cli.phar/vendor
+WP_CLI phar path:	/home/user/wp-cli-valet-command
+WP-CLI packages dir:	/home/user/.wp-cli/packages/
+WP-CLI global config:	/home/user/.wp-cli/config.yml
+WP-CLI project config:	
+WP-CLI version:	1.4.1
+```
+
+Update, if needed, to the latest stable release with `wp cli update`.
 
 #### Loading the wp-cli-valet-command package
 
-Once you've done so, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
+Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
+
+### Troubleshooting
+
+`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
+The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
+
+Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
+
+At this point, you can: 1) Either create a `wp-config.php` file manually or use the `wp config` command, or 2) use `wp valet destroy site` and try again using the `--dbpass` attribute.
 
 Installing this package requires WP-CLI v1.3.0 or greater. Update to the latest stable release with `wp cli update`.
 

--- a/README.md
+++ b/README.md
@@ -159,11 +159,35 @@ WP-CLI version:	1.4.1
 
 Update, if needed, to the latest stable release with `wp cli update`.
 
+#### Setting defaults for the wp valet command
+As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
+
+Simply add the appropriate details in `~/.wp-cli/config.yml`:
+
+```
+valet new:
+	project: wp
+	# in: override - defaults to current directory
+    version: latest
+    # locale: - use if not English
+    db: mysql
+    # dbname: defaults to wp_name
+    dbuser: root # or any other local user capable of creating databases (MySQL only)
+    dbpass: # enter the appropriate password if necessary (MySQL only)
+    dbprefix: wp_
+    admin_user: admin
+    admin_pass: admin
+    # unsecure - use without colon if you'd like to override HTTPS
+    # portable - see above
+```
+
+The `wp valet new` defaults are shown here as an example for clarity.
+
 #### Loading the wp-cli-valet-command package
 
 Once you've set up your environment, you can install this package with `wp package install aaemnnosttv/wp-cli-valet-command`.
 
-### Troubleshooting
+#### Troubleshooting
 
 `Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
 The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
@@ -202,7 +226,7 @@ Once you've decided to commit the time to seeing your pull request through, [ple
 
 ## Support
 
-Github issues aren't for general support questions, but there are other venues you can try: http://wp-cli.org/#support
+Github issues aren't for general support questions, but there are other venues you can try: https://wp-cli.org/#support
 
 
 *This README.md is generated dynamically from the project's codebase using `wp scaffold package-readme` ([doc](https://github.com/wp-cli/scaffold-package-command#wp-scaffold-package-readme)). To suggest changes, please submit a pull request against the corresponding part of the codebase.*

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,43 @@
+`Error: ERROR 1045 (28000): Access denied for user 'root'@'localhost'`
+The installer halts at the database creation stage because it doesn't have a password for your local `MySQL` instance.
+
+Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
+
+At this point, you can: 
+1) Either create a `wp-config.php` file manually,
+2) use `wp config`command to have wp-cli create one for you, or 
+3) use `wp valet destroy site` and try running your `wp valet new` command again, this time using the `--dbpass` attribute.
+
+### Configuring Alternate Defaults
+As with other `wp-cli` commands, you can set default attributes when running `wp valet`.
+
+Simply add the appropriate details in `~/.wp-cli/config.yml`:
+
+```yml
+valet new:
+  ## Uncomment or update the relevant lines when necessary to set your own defaults.
+  project: wp # or bedrock
+  # in: # override - defaults to current directory
+  version: latest
+  # locale:  # use if not English
+  db: mysql # or sqlite
+  # dbname: # defaults to wp_name
+  dbuser: root # or any other local user capable of creating databases (MySQL only)
+  # dbpass: # enter the appropriate password if necessary (MySQL only)
+  dbprefix: wp_
+  admin_user: admin
+  admin_pass: admin
+  ## Boolean options can also be configured, too.
+  # unsecure: false # set to true to override
+  # portable: false # set to true to override
+```
+
+The `wp valet new` defaults are shown here as an example for clarity.
+
+One simple usage for the `config.yml` could look like
+```yml
+valet new:
+  dbuser: root # or any db creating user
+  dbpass: password # set yours here
+```
+to enable `wp valet new site` to spin up a full, live, running local WordPress site in ~3 seconds without any additional parameters.

--- a/composer.json
+++ b/composer.json
@@ -47,8 +47,18 @@
                 "[![Travis Build](https://img.shields.io/travis/aaemnnosttv/wp-cli-valet-command/master.svg)](https://travis-ci.org/aaemnnosttv/wp-cli-valet-command)",
                 "[![Packagist](https://img.shields.io/packagist/v/aaemnnosttv/wp-cli-valet-command.svg)](https://packagist.org/packages/aaemnnosttv/wp-cli-valet-command)"
             ],
+            "sections": [
+                "Using",
+                "Installing",
+                "Troubleshooting",
+                "Support",
+                "Contributing"
+            ],
             "installing": {
                 "pre": "PREREQUISITES.md"
+            },
+            "troubleshooting": {
+                "pre": "TROUBLESHOOTING.md"
             }
         }
     }


### PR DESCRIPTION
Updating per #26.

Also tidying pre-req install instructions so that a new user can more easily hop in (linking to Homebrew, Valet without version # attached, CLI directly, etc.).

Installing the `wp-cli-valet-command` is just a single operation for veteran users, but takes a few steps to get going in a terminal.

**Rationale:** Essentially, as `composer` and `php` power most of what's going on here, there's no reason to call this "MacOS only" - we need to encourage the fully open space where Linux devs work, too. This plugin is a "killer feature" of `wp-cli` + `valet` and needs to be shared more widely; without accurate documentation it will fall by the wayside.