### PR TITLE
Add compatibility with Valet's new TLD command

### DIFF
--- a/src/Process/SystemValet.php
+++ b/src/Process/SystemValet.php
@@ -13,7 +13,10 @@ class SystemValet extends ShellCommand implements ValetInterface
      */
     public function domain()
     {
-        return trim($this->run('domain')->stdout);
+        $result = $this->run('domain')->stdout);
+        // get just the tld suffix from the response
+        preg_match('/(?:\.?)([\S]*)*$/', $result, $matches);
+        return trim($matches[0], '.');
     }
 
     /**


### PR DESCRIPTION
This extracts just the TLD from response message, and retains compatibility with older versions which didn't output additional text