### PR TITLE
Resolve compatibility issues with latest Valet

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace WP_CLI_Valet;
+
+/**
+ * @method static get(string $key)
+ */
+class Config extends Facade
+{
+    public static function getContainerKey()
+    {
+        return 'config';
+    }
+}

--- a/src/Process/FakeValet.php
+++ b/src/Process/FakeValet.php
@@ -4,17 +4,6 @@ namespace WP_CLI_Valet\Process;
 
 class FakeValet implements ValetInterface
 {
-
-    /**
-     * Get the local domain served by Valet.
-     *
-     * @return string
-     */
-    public function domain()
-    {
-        return 'dev';
-    }
-
     /**
      * Secure the installation with a self-signed TLS certificate.
      *

--- a/src/Process/SystemValet.php
+++ b/src/Process/SystemValet.php
@@ -7,16 +7,6 @@ class SystemValet extends ShellCommand implements ValetInterface
     protected $command = 'valet';
 
     /**
-     * Get the local domain served by Valet.
-     *
-     * @return string
-     */
-    public function domain()
-    {
-        return trim($this->run('domain')->stdout);
-    }
-
-    /**
      * Secure the installation with a self-signed TLS certificate.
      *
      * @param string $domain

--- a/src/Process/ValetInterface.php
+++ b/src/Process/ValetInterface.php
@@ -5,13 +5,6 @@ namespace WP_CLI_Valet\Process;
 interface ValetInterface
 {
     /**
-     * Get the local domain served by Valet.
-     *
-     * @return string
-     */
-    public function domain();
-
-    /**
      * Secure the installation with a self-signed TLS certificate.
      *
      * @param $domain

--- a/src/Props.php
+++ b/src/Props.php
@@ -33,7 +33,7 @@ class Props
      */
     public function populate()
     {
-        $this->site_name = preg_replace('/^a-zA-Z/', '-', $this->positional[0]);
+        $this->site_name = preg_replace('/[^a-zA-Z0-9\.]/', '-', $this->positional[0]);
         $this->domain    = sprintf('%s.%s', $this->site_name, Valet::domain());
     }
 

--- a/src/Props.php
+++ b/src/Props.php
@@ -34,7 +34,7 @@ class Props
     public function populate()
     {
         $this->site_name = preg_replace('/[^a-zA-Z0-9\.]/', '-', $this->positional[0]);
-        $this->domain    = sprintf('%s.%s', $this->site_name, Valet::domain());
+        $this->domain    = sprintf('%s.%s', $this->site_name, Config::get('tld') ?: Config::get('domain'));
     }
 
     /**

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -48,6 +48,11 @@ class ValetCommand
         $container->singleton('valet', getenv('BEHAT_RUN') ? FakeValet::class : SystemValet::class);
         $container->singleton('wp', SystemWp::class);
         $container->singleton('composer', SystemComposer::class);
+        $container->singleton('config', function () {
+            return getenv('BEHAT_RUN')
+                ? new ValetConfig(['tld' => 'dev'])
+                : ValetConfig::loadSystem();
+        });
 
         $container->bind('wp-installer', WordPressInstaller::class);
         $container->bind('bedrock-installer', BedrockInstaller::class);

--- a/src/ValetConfig.php
+++ b/src/ValetConfig.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace WP_CLI_Valet;
+
+class ValetConfig
+{
+    protected $data;
+
+    /**
+     * ValetConfig constructor.
+     *
+     * @param $data
+     */
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public static function loadSystem()
+    {
+        $config_path = file_exists("{$_SERVER['HOME']}/.config/valet/config.json")
+            ? "{$_SERVER['HOME']}/.config/valet/config.json"
+            : "{$_SERVER['HOME']}/.valet/config.json";
+
+        if (! file_exists($config_path)) {
+            throw new \Exception('Valet configuration file not found.');
+        }
+
+        return new static(json_decode(file_get_contents($config_path), true));
+    }
+
+    public function get($key)
+    {
+        return isset($this->data[$key]) ? $this->data[$key] : null;
+    }
+}


### PR DESCRIPTION
The wp-cli-valet command uses the `valet domain` command internally to get the configured TLD Valet uses for serving its sites.

This (Valet) command recently changed in a backwards-incompatible way with the introduction of the `tld` command.

This PR removes the dependency on `valet domain` and instead reaches for the value it needs directly from the Valet configuration file.

Resolves #39 