### PR TITLE
Fix random failing build

### DIFF
--- a/features/steps/given.php
+++ b/features/steps/given.php
@@ -161,5 +161,5 @@ $steps->Given('/^a random project name as {PROJECT}$/', function($world) {
 });
 
 $steps->Given('/^a random string as {(\w+)}$/', function($world, $var_name) {
-    $world->variables[ $var_name ] = substr(md5(uniqid('', true)), 0, 8);
+    $world->variables[ $var_name ] = substr(uniqid('v'), 0, 8); // ensure the string starts with a letter
 });


### PR DESCRIPTION
This PR aims to fix #45, a problem where builds on Travis seem to fail randomly, and silently, resulting in ultimately a failure due to Behat timing out after receiving now output for 300s.

After some extensive debugging, the problem seems to stem from an internal Behat helper that generates a random string used in just about all scenarios. It seems that `wp core install` will fail if the passed db prefix begins with a number. This triggers notices about invalid MySql and WP-CLI ends with this error:
> Error: Installation produced database errors, and may have partially or completely failed. 

However, this error does not seem to get caught when run through Valet, causing it to get stuck.

The first thing to fix is the random string, ensuring that it always starts with a letter. This should fix the build. From there, the command can be updated to not accept an invalid database prefix.