### PR TITLE
Add ability to customise the `dbhost` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ _ready-to-use in your browser_ faster than you can put your pants on.
 		  - sqlite
 		---
 
+    [--dbhost=<dbhost>]
+        Database host.
+        Defaults to 'localhost'.
+
 	[--dbname=<dbname>]
 		Database name (MySQL only).
 		Defaults to 'wp_<name>'.
@@ -126,7 +130,7 @@ this install over https.
 
 ## Installing
 
-This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists. 
+This command leverages [Laravel Valet](https://laravel.com/docs/valet) -- an open source development environment for Mac + \*nix minimalists.
 
 It runs various commands lightning fast, allowing you to spin up a site in your browser immediately after creating it, without any other configuration, all from a single command.
 
@@ -149,7 +153,7 @@ WP-CLI vendor dir:	phar://wp-cli.phar/vendor
 WP_CLI phar path:	/home/user/wp-cli-valet-command
 WP-CLI packages dir:	/home/user/.wp-cli/packages/
 WP-CLI global config:	/home/user/.wp-cli/config.yml
-WP-CLI project config:	
+WP-CLI project config:
 WP-CLI version:	1.4.1
 ```
 
@@ -170,9 +174,9 @@ The installer halts at the database creation stage because it doesn't have a pas
 
 Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
 
-At this point, you can: 
+At this point, you can:
 1) Either create a `wp-config.php` file manually,
-2) use `wp config`command to have wp-cli create one for you, or 
+2) use `wp config`command to have wp-cli create one for you, or
 3) use `wp valet destroy site` and try running your `wp valet new` command again, this time using the `--dbpass` attribute.
 
 ### Configuring Alternate Defaults

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,9 +3,9 @@ The installer halts at the database creation stage because it doesn't have a pas
 
 Prevent this from happening by appending your `wp valet` commands like such: `wp valet new site --dbpass=local_root_password`.
 
-At this point, you can: 
+At this point, you can:
 1) Either create a `wp-config.php` file manually,
-2) use `wp config`command to have wp-cli create one for you, or 
+2) use `wp config`command to have wp-cli create one for you, or
 3) use `wp valet destroy site` and try running your `wp valet new` command again, this time using the `--dbpass` attribute.
 
 ### Configuring Alternate Defaults
@@ -21,6 +21,7 @@ valet new:
   version: latest
   # locale:  # use if not English
   db: mysql # or sqlite
+  # dbhost: # defaults to localhost
   # dbname: # defaults to wp_name
   dbuser: root # or any other local user capable of creating databases (MySQL only)
   # dbpass: # enter the appropriate password if necessary (MySQL only)

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -40,7 +40,7 @@ class BedrockInstaller extends WordPressInstaller
                 'database_name',
                 'database_user',
                 'database_password',
-                'database_host',
+                '# DB_HOST=localhost',
                 'http://example.com',
                 '# DB_PREFIX=wp_'
             ],
@@ -48,7 +48,7 @@ class BedrockInstaller extends WordPressInstaller
                 $this->props->databaseName(),
                 $this->props->option('dbuser'),
                 $this->props->databasePassword(),
-                $this->props->option('dbhost', 'localhost'),
+                sprintf('DB_HOST=%s', $this->props->option('dbhost', 'localhost')),
                 $this->props->fullUrl(),
                 sprintf('DB_PREFIX=%s', $this->props->option('dbprefix'))
             ],

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -101,6 +101,10 @@ class ValetCommand
      *   - sqlite
      * ---
      *
+     * * [--dbhost=<dbhost>]
+     * : Database host.
+     * Defaults to 'localhost'.
+     *
      * [--dbname=<dbname>]
      * : Database name (MySQL only).
      * Defaults to 'wp_<name>'.


### PR DESCRIPTION
It looks like there was reference to this in `BedrockInstaller.php`, but never actually fully implemented. I've added the parameter to the docs in `ValetCommand.php`, and updated the installer to replace the parameter.

The only thing that may need to be considered, is that this will un-comment `DB_HOST` across all installations, regardless of whether you customise the `dbhost` parameter or not.