### PR TITLE
CI updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: php
 
 php:
+  - 7.3
   - 7.2
   - 7.1
-  - 7.0
-  - 5.6
 
 install: travis_retry composer install
 
@@ -13,7 +12,7 @@ before_script:
   - mysql -e 'CREATE DATABASE wp_cli_test;' -uroot
   - mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 
-script: composer run-behat
+script: composer behat
 
 notifications:
   email:

--- a/behat.yml
+++ b/behat.yml
@@ -1,0 +1,4 @@
+default:
+  paths:
+    features: features
+    bootstrap: features/bootstrap

--- a/command.php
+++ b/command.php
@@ -2,6 +2,6 @@
 
 use WP_CLI_Valet\ValetCommand;
 
-if (defined('WP_CLI') && WP_CLI) {
+if (defined('WP_CLI') && WP_CLI && class_exists(ValetCommand::class)) {
     ValetCommand::register();
 }

--- a/composer.json
+++ b/composer.json
@@ -34,16 +34,17 @@
     },
     "require-dev": {
         "aaemnnosttv/wp-sqlite-db": "^1.0",
-        "behat/behat": "~2.5",
         "koodimonni/composer-dropin-installer": "^1.2",
+        "roave/security-advisories": "dev-master",
         "roots/bedrock": "^1.8",
         "wp-cli/entity-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",
-        "wp-cli/scaffold-package-command": "^0.5.0"
+        "wp-cli/scaffold-package-command": "^0.5.0",
+        "wp-cli/wp-cli-tests": "^2.0"
     },
     "scripts": {
-        "update-readme": "wp scaffold package-readme . --force",
-        "run-behat": "behat --ansi"
+        "behat": "run-behat-tests",
+        "update-readme": "wp scaffold package-readme . --force"
     },
     "extra": {
         "commands": [


### PR DESCRIPTION
This PR fixes a recent break to the build as well as makes a few updates to the build configuration.

* Adds `wp-cli/wp-cli-tests` test framework
* Drops EOL PHP versions (5.6, 7.0) from test matrix
* Adds PHP 7.3 to test matrix