### PR TITLE
Clarification on need to register site with Valet

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ wp valet new <name> [--project=<project>] [--in=<dir>] [--version=<version>] [--
 This command will spin up a new WordPress installation -- complete with database and https
 _ready-to-use in your browser_ faster than you can put your pants on.
 
+**NB** If you have not used `valet park` for the directory or parent directory you are running the installation in you need to do a `valet link` to make sure the site will run without running into 404s.
+
 **OPTIONS**
 
 	<name>

--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ wp valet new <name> [--project=<project>] [--in=<dir>] [--version=<version>] [--
 This command will spin up a new WordPress installation -- complete with database and https
 _ready-to-use in your browser_ faster than you can put your pants on.
 
-**NB** If you have not used `valet park` for the directory or parent directory you are running the installation in you need to do a `valet link` to make sure the site will run without running into 404s.
-
 **OPTIONS**
 
 	<name>

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -63,6 +63,10 @@ class ValetCommand
      *
      * This command will spin up a new WordPress installation -- complete with database and https
      * _ready-to-use in your browser_ faster than you can put your pants on.
+     * 
+     * **NB** If you have not used `valet park` for the directory or parent directory you are 
+     * running the installation in you need to do a `valet link` to make sure the site will run
+     * without running into 404s.
      *
      * ## OPTIONS
      *


### PR DESCRIPTION
See https://github.com/aaemnnosttv/wp-cli-valet-command/issues/15 where we ran into 404 issues due to not having done a valet park in the directory the installation was done nor a `valet link`.