### PR TITLE
Fix build for xenial dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+services:
+  - mysql
+
 php:
   - 7.3
   - 7.2


### PR DESCRIPTION
Newer distributions of Travis don't start the mysql service for more performant test runs and require that it be declared to be started automatically.

https://docs.travis-ci.com/user/reference/xenial#services-disabled-by-default