### PR TITLE
Fix error during Bedrock installs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "illuminate/container": "^5.1",
+        "illuminate/container": ">=5.1 <5.7",
         "symfony/filesystem": "^2.7 || ^3 || ^4",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",

--- a/features/valet-new-project-bedrock.feature
+++ b/features/valet-new-project-bedrock.feature
@@ -1,5 +1,6 @@
 Feature: It can create new installs for Valet-supported WordPress projects.
 
+  @issue-62
   Scenario: Create a new Bedrock install.
     Given an empty directory
     And a random project name as {PROJECT}

--- a/features/valet-new-project-bedrock.feature
+++ b/features/valet-new-project-bedrock.feature
@@ -52,7 +52,7 @@ Feature: It can create new installs for Valet-supported WordPress projects.
     When I run `wp valet new {PROJECT} --project=bedrock --in={PATH} --dbprefix=foo`
     Then the {PATH}/{PROJECT}/.env file should contain:
       """
-      DB_PREFIX=foo
+      DB_PREFIX='foo'
       """
     And I run `wp eval 'echo getenv("DB_PREFIX");' --path={PATH}/{PROJECT}/web/wp/`
     Then STDOUT should be:

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -42,7 +42,6 @@ class BedrockInstaller extends WordPressInstaller
                 'database_password',
                 'database_host',
                 'http://example.com',
-                '# DB_PREFIX=wp_'
             ],
             [
                 $this->props->databaseName(),
@@ -50,9 +49,14 @@ class BedrockInstaller extends WordPressInstaller
                 $this->props->databasePassword(),
                 $this->props->option('dbhost', 'localhost'),
                 $this->props->fullUrl(),
-                sprintf('DB_PREFIX=%s', $this->props->option('dbprefix'))
             ],
             file_get_contents($this->props->fullPath('.env.example'))
+        );
+        // DB_PREFIX value is quoted in newer versions, not in older.
+        $env_contents = preg_replace(
+            '/# DB_PREFIX=.*/',
+            sprintf('DB_PREFIX=\'%s\'', $this->props->option('dbprefix')),
+            $env_contents
         );
 
         file_put_contents($this->props->fullPath('.env'), $env_contents);


### PR DESCRIPTION
This PR fixes a fatal error that was preventing Bedrock installs from being created due to a conflict with `illuminate/support` which isn't required by this command, but a dependency of newer versions of `illuminate/container` (which is).

It also updates some of the rewriting that happens for `.env` for compatibility with the newer quoted format.

Resolves #62 