### PR TITLE
Fix broken tests and compatibility with PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,9 @@ services:
   - mysql
 
 php:
+  - 8.0
   - 7.4
-  - 7.3
-  - 7.2
+  - 5.6
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "wp-cli/entity-command": "^1 || ^2",
         "wp-cli/eval-command": "^1 || ^2",
         "wp-cli/scaffold-package-command": "^0.5.0",
-        "wp-cli/wp-cli-tests": "^3"
+        "wp-cli/wp-cli-tests": "^3.0.15"
     },
     "scripts": {
         "behat": "run-behat-tests",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "illuminate/container": ">=5.1 <5.7 || >6.5",
+        "illuminate/container": ">=5.1 <5.7 || ^6.5.1 || ^7 || ^8",
         "symfony/filesystem": "^2.7 || ^3 || ^4",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require": {
         "php": ">=5.5",
-        "illuminate/container": ">=5.1 <5.7",
+        "illuminate/container": ">=5.1 <5.7 || >6.5",
         "symfony/filesystem": "^2.7 || ^3 || ^4",
         "wp-cli/config-command": "^1 || ^2",
         "wp-cli/core-command": "^1 || ^2",

--- a/features/valet-new-project-bedrock.feature
+++ b/features/valet-new-project-bedrock.feature
@@ -17,6 +17,7 @@ Feature: It can create new installs for Valet-supported WordPress projects.
       | ID | user_login | user_email          |
       | 1  | admin      | admin@{PROJECT}.dev |
 
+  @db:sqlite
   Scenario: It can create a new Bedrock install using sqlite instead of MySql.
     Given an empty directory
     And a random project name as {PROJECT}

--- a/features/valet-new.feature
+++ b/features/valet-new.feature
@@ -48,6 +48,7 @@ Feature: Create a new install.
       | ID | user_login   | user_email          |
       | 1  | {ADMIN}      | hello@{PROJECT}.dev |
 
+  @db:sqlite
   Scenario: It can create a new WordPress install using sqlite for the database.
     Given an empty directory
     And a random project name as {PROJECT}
@@ -60,6 +61,7 @@ Feature: Create a new install.
       Success: {PROJECT} ready! https://{PROJECT}.dev
       """
 
+  @db:sqlite
   Scenario: It can create a new portable WordPress install.
     Given an empty directory
     And a random project name as {PROJECT}
@@ -84,7 +86,7 @@ Feature: Create a new install.
       """
     And the wp_app_{PROJECT} database should exist
 
-  @issue-51
+  @db:sqlite @issue-51
   Scenario: skip-content is compatible with using sqlite for the DB.
     Given an empty directory
     And a wp-cli.yml file:

--- a/src/Composer.php
+++ b/src/Composer.php
@@ -9,6 +9,7 @@ namespace WP_CLI_Valet;
  * @method static config(...$args)
  * @method static createProject(...$args)
  * @method static install(...$args)
+ * @method static update(...$args)
  * @method static _require(...$args)
  */
 class Composer extends Facade

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -24,7 +24,15 @@ class BedrockInstaller extends WordPressInstaller
 
         Composer::createProject('roots/bedrock', $this->props->site_name, [
             'working-dir'    => $this->props->parentDirectory(),
+            'no-install'     => true,
             'no-interaction' => true,
+            'no-dev'         => true,
+        ]);
+        // Install dependencies with updates (required for older PHP)
+        Composer::update([
+            'working-dir'    => $this->props->parentDirectory(),
+            'no-interaction' => true,
+            'no-dev'         => true,
         ]);
     }
 

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -30,7 +30,7 @@ class BedrockInstaller extends WordPressInstaller
         ]);
         // Install dependencies with updates (required for older PHP)
         Composer::update([
-            'working-dir'    => $this->props->parentDirectory(),
+            'working-dir'    => $this->props->projectRoot(),
             'no-interaction' => true,
             'no-dev'         => true,
         ]);

--- a/tests/Context/FeatureContext.php
+++ b/tests/Context/FeatureContext.php
@@ -41,17 +41,4 @@ class FeatureContext extends \WP_CLI\Tests\Context\FeatureContext
             throw new Exception("Failed to assert that a database exists with the name '$database_name'");
         }
     }
-
-    /**
-     * Note: this method is a modified version of the core method
-     * to fix directory existence assertions until fixed upstream.
-     *
-     * @see https://github.com/wp-cli/wp-cli-tests/pull/127
-     */
-    public function then_a_specific_file_folder_should_exist($path, $type, $action, $expected = null)
-    {
-        clearstatcache(false, $path);
-
-        parent::then_a_specific_file_folder_should_exist($path, $type, $action, $expected);
-    }
 }


### PR DESCRIPTION
Tests started failing after changes were introduced to wp-cli-tests which broke a temporary workaround that was in place.

See https://github.com/wp-cli/wp-cli-tests/pull/127

This PR also updates the version constraint for `illuminate/container` to support newer versions. It was previously locked to a specific 5.x range due to inclusion of `illuminate/support` in later versions, but this was since removed in https://github.com/laravel/framework/pull/30518 (https://github.com/illuminate/container/releases/tag/v6.5.1).