### PR TITLE
Add support for customizing dbhost for new sites

### DIFF
--- a/features/valet-new-project-bedrock.feature
+++ b/features/valet-new-project-bedrock.feature
@@ -60,3 +60,18 @@ Feature: It can create new installs for Valet-supported WordPress projects.
       """
       foo
       """
+
+  @issue-73
+  Scenario: It supports using an alternate DB host via the dbhost flag.
+    Given an empty directory
+    And a random project name as {PROJECT}
+    When I run `wp valet new {PROJECT} --project=bedrock --dbhost=127.0.0.1`
+    Then the {PROJECT}/.env file should contain:
+      """
+      DB_HOST='127.0.0.1'
+      """
+    And I run `wp eval 'echo getenv("DB_HOST");' --path={PROJECT}/web/wp/`
+    Then STDOUT should be:
+      """
+      127.0.0.1
+      """

--- a/features/valet-new.feature
+++ b/features/valet-new.feature
@@ -86,6 +86,22 @@ Feature: Create a new install.
       """
     And the wp_app_{PROJECT} database should exist
 
+  @issue-73
+  Scenario: It supports using an alternate DB host via the dbhost flag.
+    Given an empty directory
+    And a random project name as {PROJECT}
+    When I run `wp valet new app.{PROJECT} --dbhost=127.0.0.1`
+    Then STDOUT should contain:
+      """
+      Success: app.{PROJECT} ready! https://app.{PROJECT}.dev
+      """
+    And the wp_app_{PROJECT} database should exist
+    When I run `wp config get DB_HOST --path=app.{PROJECT}`
+    Then STDOUT should be:
+      """
+      127.0.0.1
+      """
+
   @db:sqlite @issue-51
   Scenario: skip-content is compatible with using sqlite for the DB.
     Given an empty directory

--- a/src/Installer/BedrockInstaller.php
+++ b/src/Installer/BedrockInstaller.php
@@ -62,8 +62,13 @@ class BedrockInstaller extends WordPressInstaller
         );
         // DB_PREFIX value is quoted in newer versions, not in older.
         $env_contents = preg_replace(
-            '/# DB_PREFIX=.*/',
+            '/^# DB_PREFIX=.*/m',
             sprintf('DB_PREFIX=\'%s\'', $this->props->option('dbprefix')),
+            $env_contents
+        );
+        $env_contents = preg_replace(
+            '/^# DB_HOST=.*/m',
+            sprintf('DB_HOST=\'%s\'', $this->props->option('dbhost', 'localhost')),
             $env_contents
         );
 

--- a/src/Installer/WordPressInstaller.php
+++ b/src/Installer/WordPressInstaller.php
@@ -61,10 +61,11 @@ class WordPressInstaller implements InstallerInterface
      */
     public function configure()
     {
-        WP::core('config', [
+        WP::config('create', [
             'dbname'   => $this->props->databaseName(),
             'dbuser'   => $this->props->option('dbuser'),
             'dbpass'   => $this->props->databasePassword(),
+            'dbhost'   => $this->props->option('dbhost'),
             'dbprefix' => $this->props->option('dbprefix'),
         ]);
     }

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -117,6 +117,12 @@ class ValetCommand
      * Default: ''
      * ---
      *
+     * [--dbhost=<dbhost>]
+     * : Set the database host.
+     * ---
+     * default: localhost
+     * ---
+     *
      * [--dbprefix=<dbprefix>]
      * : Set the database table prefix.
      * ---

--- a/src/WP.php
+++ b/src/WP.php
@@ -6,6 +6,7 @@ namespace WP_CLI_Valet;
  * Class WP
  * @package WP_CLI_Valet
  *
+ * @method static void config(...$args)
  * @method static void core(...$args)
  * @method static void db(...$args)
  */


### PR DESCRIPTION
This PR adds support for the `--dbhost=<hostname>` flag as used by the `wp config create` command.

Closes #73 