### PR TITLE
Add Multisite Support

### DIFF
--- a/src/Installer/WordPressInstaller.php
+++ b/src/Installer/WordPressInstaller.php
@@ -111,6 +111,18 @@ class WordPressInstaller implements InstallerInterface
     {
         Command::debug('Installing WordPress');
 
+        if ($this->props->isMultisite()) {
+            $this->runMultisiteInstall();
+        } else {
+            $this->runSingleInstall();
+        }
+    }
+
+    /**
+     * Run single site WordPress install.
+     */
+    protected function runSingleInstall()
+    {
         WP::core('install', [
             'url'            => $this->props->fullUrl(),
             'title'          => $this->props->site_name,
@@ -119,6 +131,27 @@ class WordPressInstaller implements InstallerInterface
             'admin_email'    => $this->props->option('admin_email', "admin@{$this->props->domain}"),
             'skip-email'     => true
         ]);
+    }
+
+    /**
+     * Run multisite network WordPress install.
+     */
+    protected function runMultisiteInstall()
+    {
+        $args = [
+            'url'            => $this->props->fullUrl(),
+            'title'          => $this->props->site_name,
+            'admin_user'     => $this->props->option('admin_user'),
+            'admin_password' => $this->props->option('admin_password'),
+            'admin_email'    => $this->props->option('admin_email', "admin@{$this->props->domain}"),
+            'skip-email'     => true
+        ];
+
+        if ($this->props->isSubdomains()) {
+            $args['subdomains'] = true;
+        }
+
+        WP::core('multisite-install', $args);
     }
 
     /**

--- a/src/Props.php
+++ b/src/Props.php
@@ -130,6 +130,26 @@ class Props
     }
 
     /**
+     * Whether or not the install will be a multisite network.
+     *
+     * @return bool
+     */
+    public function isMultisite()
+    {
+        return (bool) $this->option('network') || $this->option('subdomains');
+    }
+
+    /**
+     * Whether or not the install will use subdomains for multisite.
+     *
+     * @return bool
+     */
+    public function isSubdomains()
+    {
+        return (bool) $this->option('subdomains');
+    }
+
+    /**
      * Get an option value by name.
      *
      * @param      $name

--- a/src/ValetCommand.php
+++ b/src/ValetCommand.php
@@ -154,6 +154,12 @@ class ValetCommand
      * [--portable]
      * : Provision the site to be portable. Implies --unsecure and --db=sqlite.
      *
+     * [--network]
+     * : Install WordPress as a multisite network.
+     *
+     * [--subdomains]
+     * : Use subdomains for multisite. Implies --network.
+     *
      * @subcommand new
      *
      * @when before_wp_load


### PR DESCRIPTION
This PR adds support for creating WordPress multisite installations with the `wp valet new` command.

## Changes

### New Options

- `--network` - Install WordPress as a multisite network
- `--subdomains` - Use subdomains for multisite (implies --network)

### Files Changed

| File | Changes |
|------|---------|
| `src/ValetCommand.php` | Added `--network` and `--subdomains` options to docblock |
| `src/Props.php` | Added `isMultisite()` and `isSubdomains()` methods |
| `src/Installer/WordPressInstaller.php` | Added `runMultisiteInstall()` method using `wp core multisite-install` |

## Usage

```bash
# Subdirectory multisite (default)
wp valet new mysite --network

# Subdomain multisite
wp valet new mysite --network --subdomains

# Portable multisite (SQLite + HTTP)
wp valet new mysite --portable --network
```

## Backward Compatibility

- Single site installations work as before (default)
- Bedrock projects inherit multisite support via parent class

## Testing

Tested with:
- Single site install (default)
- Multisite with subdirectories
- Multisite with subdomains
- Portable multisite with SQLite